### PR TITLE
Bump zwasm v1.6.1 → v1.7.2

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.3.0",
     .dependencies = .{
         .zwasm = .{
-            .url = "https://github.com/clojurewasm/zwasm/archive/v1.6.1.tar.gz",
-            .hash = "zwasm-1.6.0-IBbzFxlNJABErVzYJGZtcE4EzBw26P4XziZAj8CywE4M",
+            .url = "https://github.com/clojurewasm/zwasm/archive/v1.7.2.tar.gz",
+            .hash = "zwasm-1.6.0-IBbzF3K-KQA1omPPy63QNlvEWV4uV-qS8xmwORW1cV_I",
         },
     },
     .fingerprint = 0x62a7be489d633543,


### PR DESCRIPTION
## Summary
- Bumps the zwasm dependency from v1.6.1 to v1.7.2.
- v1.7.2 fixes an ARM64 JIT remainder bug (\`rd == rs2\` aliasing) that surfaces in \`02_tinygo_test\` — TinyGo's \`gcd\` lowers to IR \`r3 = r0 % r3\`, and after JIT compilation (HOT_THRESHOLD=3) the loop produced wrong remainders and spun for minutes.
- Also picks up v1.7.1 (invoke() settings persistence + build options + spec bump) and v1.7.0 (SIMD JIT, memory64 fix, FD-based WASI, JIT correctness sweep).

## Test plan
- [x] \`bash test/run_all.sh\`: zig test, ReleaseSafe build, \`cljw test\` (83 namespaces, 0 failures), e2e wasm, deps.edn e2e — all PASS
- [x] Binary size: 4.76 MB (≤ 5.0 MB)
- [x] Startup: 4.5 ms ± 0.6 ms (≤ 6 ms)
- [x] RSS: 7.65 MB (≤ 10 MB)
- [x] \`bash bench/wasm_bench.sh --quick\`: gcd completes in 66.2 ms (was hanging on v1.7.0/v1.7.1)

## Regression context
Investigated at the zwasm side: the prior fix for rem aliasing (zwasm v1.7.1) covered only \`rd == rs1\`. The register allocator can also assign the destination to the same physical register as the divisor; in that case UDIV clobbered the divisor before MSUB could use it. zwasm v1.7.2 now preserves whichever operand the destination aliases and adds a regression test.