### PR TITLE
Bump zwasm v1.7.2 → v1.8.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.3.0",
     .dependencies = .{
         .zwasm = .{
-            .url = "https://github.com/clojurewasm/zwasm/archive/v1.7.2.tar.gz",
-            .hash = "zwasm-1.6.0-IBbzF3K-KQA1omPPy63QNlvEWV4uV-qS8xmwORW1cV_I",
+            .url = "https://github.com/clojurewasm/zwasm/archive/v1.8.0.tar.gz",
+            .hash = "zwasm-1.8.0-IBbzF7LPKQAqq50dY7Kj8RQhPulvoxIf7dEkHcvp27Ix",
         },
     },
     .fingerprint = 0x62a7be489d633543,


### PR DESCRIPTION
## Summary
- Updates zwasm to v1.8.0 which introduces the `WasmModule.Config` unified loading API (PR clojurewasm/zwasm#30 by @jtakakura).
- All existing `load*` helpers are retained as thin wrappers, so CW call sites do not need changes.
- Local verification on this branch: `bash test/run_all.sh --quick` → 4/4 PASS (zig build test, cljw test 83 namespaces, e2e wasm, deps.edn e2e).

## Notable zwasm v1.8.0 behavioral changes (for awareness)
1. Fuel now persists across invocations (matches the existing `/// Persistent fuel budget` doc comment). CW does not use the fuel API, so no impact here.
2. Resource limits apply during the start function. CW does not set these, no impact.
3. CLI `--link` retry scoped to `ImportNotFound`. CLI-only, no CW impact.

See https://github.com/clojurewasm/zwasm/blob/main/CHANGELOG.md#180---2026-04-21 for the full release notes.

## Test plan
- [x] `zig build test` on macOS aarch64 (with zwasm pinned locally to develop/pr30-integration: PASS)
- [x] `bash test/run_all.sh --quick` on macOS aarch64: 4/4 PASS
- [ ] CI green across Mac + Ubuntu (will be verified by GitHub Actions on this PR)